### PR TITLE
fix: handle the situation when there are no kobo forms

### DIFF
--- a/bahis_management/desk/views.py
+++ b/bahis_management/desk/views.py
@@ -33,16 +33,26 @@ def get_kobotoolbox_forms():
 
     api_token = env("KOBOTOOLBOX_API_TOKEN")
 
-    response = requests.get(f"{api_url}assets/?format=json", headers={"Authorization": f"Token {api_token}"})
+    response = requests.get(
+        f"{api_url}assets/?format=json", headers={"Authorization": f"Token {api_token}"}
+    )
     asset_list = response.json().get("results")
 
     form_options = []
     if asset_list:
-        deployed_form_list = [asset for asset in asset_list if asset.get("has_deployment", False)]
+        deployed_form_list = [
+            asset for asset in asset_list if asset.get("has_deployment", False)
+        ]
 
         form_options.append({"id": None, "name": "--------", "description": ""})
     else:
-        form_options.append({"id": None, "name": "--------", "description": "There are no forms in the BAHIS KoboToolbox instance"})
+        form_options.append(
+            {
+                "id": None,
+                "name": "--------",
+                "description": "There are no forms in the BAHIS KoboToolbox instance",
+            }
+        )
 
     for form in deployed_form_list:
         form_options.append(
@@ -72,7 +82,9 @@ class KoboToolboxFormPicker(TextInput):
 
         if attrs is not None:
             flat_attrs = flatatt(attrs)
-            html = f'  <select name="{name}" {flat_attrs}> ' + form_options + "</select>"
+            html = (
+                f'  <select name="{name}" {flat_attrs}> ' + form_options + "</select>"
+            )
         else:
             html = f'  <select name="{name}"> ' + form_options + "</select>"
         return mark_safe(html)
@@ -93,7 +105,9 @@ class MaterialUIIconPicker(TextInput):
             if value:
                 html = f'<input name={name} type="text" class="use-material-icon-picker" value={value}>'
             else:
-                html = f'<input name={name} type="text" class="use-material-icon-picker">'
+                html = (
+                    f'<input name={name} type="text" class="use-material-icon-picker">'
+                )
         return mark_safe(html)
 
 
@@ -118,7 +132,9 @@ class ModuleList(FilterView):
 
         # use paginator range with ellipses for simplicity
         page = context["page_obj"]
-        context["paginator_range"] = page.paginator.get_elided_page_range(page.number, on_each_side=2, on_ends=2)
+        context["paginator_range"] = page.paginator.get_elided_page_range(
+            page.number, on_each_side=2, on_ends=2
+        )
 
         return context
 
@@ -215,7 +231,9 @@ class WorkflowCreate(CreateView):
         return super(WorkflowCreate, self).form_valid(form)
 
     def form_invalid(self, form):
-        messages.error(self.request, "The module workflow was not created successfully.")
+        messages.error(
+            self.request, "The module workflow was not created successfully."
+        )
         form.error_css_class = "error"
         return super(WorkflowCreate, self).form_invalid(form)
 

--- a/bahis_management/desk/views.py
+++ b/bahis_management/desk/views.py
@@ -36,10 +36,13 @@ def get_kobotoolbox_forms():
     response = requests.get(f"{api_url}assets/?format=json", headers={"Authorization": f"Token {api_token}"})
     asset_list = response.json().get("results")
 
-    deployed_form_list = [asset for asset in asset_list if asset.get("has_deployment", False)]
-
     form_options = []
-    form_options.append({"id": None, "name": "--------", "description": ""})
+    if asset_list:
+        deployed_form_list = [asset for asset in asset_list if asset.get("has_deployment", False)]
+
+        form_options.append({"id": None, "name": "--------", "description": ""})
+    else:
+        form_options.append({"id": None, "name": "--------", "description": "There are no forms in the BAHIS KoboToolbox instance"})
 
     for form in deployed_form_list:
         form_options.append(


### PR DESCRIPTION
Basically, when we are creating or editing modules (or workflows) we call to the BAHIS KoboToolbox instance and get a list of forms for the user to pick from. I had not caught the situation where there were no forms in Kobo - this should fix that.