### PR TITLE
fix: add missing url tag word

### DIFF
--- a/bahis_management/templates/desk/module_update_form.html
+++ b/bahis_management/templates/desk/module_update_form.html
@@ -12,7 +12,7 @@ Update Desktop App Module
 
 {% block extra_options %}
 {% if allow_workflows %}
-    <a class="btn tooltipped" data-tooltip="See workflows for this list" href="{% 'workflows_list' object.form %}/">Workflows</a>
+    <a class="btn tooltipped" data-tooltip="See workflows for this list" href="{% url 'workflows_list' object.form %}/">Workflows</a>
 {% endif %}
 {% endblock extra_options %}
 


### PR DESCRIPTION
This error was being caused by a missing `url` keyword in the Django templates tag. Fixed here.